### PR TITLE
Fix issue in showing env display names

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -31036,7 +31036,7 @@ function main() {
             name: item.name,
             type: item.valueFrom?.configForm?.type || "string",
             required: item.valueFrom?.configForm?.required,
-            displayName: item.valueFromConfigForm?.displayName,
+            displayName: item.valueFrom?.configForm?.displayName,
           })
         }
       })

--- a/index.js
+++ b/index.js
@@ -109,7 +109,7 @@ function main() {
             name: item.name,
             type: item.valueFrom?.configForm?.type || "string",
             required: item.valueFrom?.configForm?.required,
-            displayName: item.valueFromConfigForm?.displayName,
+            displayName: item.valueFrom?.configForm?.displayName,
           })
         }
       })


### PR DESCRIPTION
This pull request includes a small change to the `index.js` file. The change corrects a typo in the property access for `displayName` to ensure the value is properly retrieved from the `configForm` object.

* [`index.js`](diffhunk://#diff-e727e4bdf3657fd1d798edcd6b099d6e092f8573cba266154583a746bba0f346L112-R112): Corrected the property access for `displayName` from `item.valueFromConfigForm?.displayName` to `item.valueFrom?.configForm?.displayName`.